### PR TITLE
Fix handling of HTTP parameter arrays

### DIFF
--- a/R/gitlab_api.R
+++ b/R/gitlab_api.R
@@ -156,7 +156,7 @@ gitlab <- function(req,
     if (!missing(max_page)) {
       dot_args <- c(dot_args, max_page = max_page)
     }
-    do.call(gitlab_con, c(dot_args, gitlab_con = "self", ...)) %>%
+    do.call(gitlab_con, c(dot_args, gitlab_con = "self", list(...))) %>%
       iff(debug, print)
   }
 }


### PR DESCRIPTION
This commit fixes a bug in `gitlab` that prevents passing arrays of arguments to the GitLab API.

In particular, prior to this PR, attempting to pass an array of parameters to `gitlab`, as in e.g.:

```r
gitlab("projects", name = "foo", path = "test/foo", topics = c("topic a", "topic b"), verb = httr::POST)
```

…  would result in the following serialisation (using JSON here, but the same is true for form-encoded):

```json
{"name": "foo", "path": "test/foo", "topics1": "topic a", "topics2": "topic b"}
```

But the GitLab API would expect an actual JSON array, and would not recognise the `topics` array in the above. With this PR, the data is sent correctly as

```json
{"name": "foo", "path": "test/foo", "topics": ["topic a", "topic b"]}
```

The reason for this is due to the way that `c(...)` flattens named parameters. To avoid flattening, use `list(...)`.