### PR TITLE
fix: tests suite working for every contributors

### DIFF
--- a/dev/create_testor_on_gitlab.R
+++ b/dev/create_testor_on_gitlab.R
@@ -22,7 +22,7 @@ set_gitlab_connection(
 projects_names <- c("testor.macos", "testor.windows", "testor.release",
                     "testor.devel", "testor.release.master", "testor.coverage")
 # Local - Only the first one is mandatory
-projects_names <- c("testor.main", "testor.master")
+projects_names <- "testor.main"
 
 # Store all outputs
 all_outputs <- list()

--- a/tests/testthat/test_projects_repos.R
+++ b/tests/testthat/test_projects_repos.R
@@ -11,9 +11,7 @@ test_that("gl_list_projects work", {
 all_user_projects <- gl_list_user_projects(user_id = test_user_id, max_page = 1, order_by = "last_activity_at")
 
 test_that("gl_list_user_projects work", {
-  some_projects <- paste0("testor.", c("macos", "windows", "release",
-     "devel", "coverage", "main", "release.master"))
-  expect_true(all(some_projects %in% all_user_projects[["name"]]))
+  expect_true(all(test_project_name %in% all_user_projects[["name"]]))
   expect_true(all(c("id", "name", "path") %in% names(all_user_projects)))
 })
 


### PR DESCRIPTION
Why:

- For contributors who were not the maintainers the test suite was not passing. The tests expected some projects that were only created on the maintainer session. Despite, the script dev/create_testor_on_gitlab.R was creating only one project "testor.main".

How:

- Test only the presence of testor projects define in the helpers by environment variable `GITLABR_TEST_PROJECT_NAME`